### PR TITLE
Version 1.0.0

### DIFF
--- a/src/dogcrud/__about__.py
+++ b/src/dogcrud/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.0.4"
+__version__ = "1.0.0"


### PR DESCRIPTION
Now that jq is removed and CI and release/publishing flow in place, bump version to 1.0.0.