### PR TITLE
Add restore for metric tags

### DIFF
--- a/src/dogcrud/__about__.py
+++ b/src/dogcrud/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/src/dogcrud/core/metric_resource_type.py
+++ b/src/dogcrud/core/metric_resource_type.py
@@ -86,8 +86,7 @@ class MetricResourceType(ResourceType):
     def transform_get_to_put(self, data: bytes) -> bytes:
         metric_tag_data = MetricTagDataModel.model_validate_json(data)
         metric_tag = MetricTagModel(data=metric_tag_data)
-        json = metric_tag.model_dump_json(exclude_none=True)
-        return json
+        return metric_tag.model_dump_json(exclude_none=True)
 
     async def _list_ids(self, cursor_pagination: CursorPagination) -> AsyncGenerator[IDType]:
         async for page in cursor_pagination.pages(f"api/{self.rest_path()}", self.concurrency_semaphore):

--- a/src/dogcrud/core/metric_resource_type.py
+++ b/src/dogcrud/core/metric_resource_type.py
@@ -6,9 +6,9 @@ import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import override
-from pydantic import BaseModel
 
 import aiofiles
+from pydantic import BaseModel
 
 from dogcrud.core import context, rest
 from dogcrud.core.pagination import CursorDataItemModel, CursorPagination

--- a/src/dogcrud/core/pagination.py
+++ b/src/dogcrud/core/pagination.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol, assert_never, override
 
 import orjson
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from dogcrud.core.resource_type import IDType
 from dogcrud.core.rest import get_json
@@ -163,8 +163,7 @@ class CursorLinksModel(BaseModel):
 
 
 class CursorDataItemModel(BaseModel):
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra='allow')
 
     id: str
 

--- a/src/dogcrud/core/rest.py
+++ b/src/dogcrud/core/rest.py
@@ -71,3 +71,15 @@ async def put_json(path: str, body: bytes) -> None:
             duration = time.perf_counter() - t0
             logger.debug(f"put_json: url={url}, body={len(body)} bytes, status={resp.status}, duration={duration:.3f}s")
             resp.raise_for_status()
+
+
+async def patch_json(path: str, body: bytes) -> None:
+    url = f"https://api.datadoghq.com/{path}"
+    headers = {"content-type": "application/json"}
+
+    async with async_run_context().concurrent_requests_semaphore:
+        t0 = time.perf_counter()
+        async with async_run_context().datadog_session.patch(url, data=body, headers=headers) as resp:
+            duration = time.perf_counter() - t0
+            logger.debug(f"patch_json: url={url}, body={len(body)} bytes, status={resp.status}, duration={duration:.3f}s")
+            resp.raise_for_status()


### PR DESCRIPTION
Add dogcrud record for v2/metrics to update tag configurations ([metrics without limits](https://docs.datadoghq.com/metrics/metrics-without-limits/)).