### PR TITLE
Types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
     - name: Run Tests
       run: hatch test
 
+    - name: Check Types
+      run: hatch run types:check
+
   check:
     if: always()
 

--- a/src/dogcrud/core/metric_metadata_resource_type.py
+++ b/src/dogcrud/core/metric_metadata_resource_type.py
@@ -42,7 +42,7 @@ class MetricMetadataResourceType(StandardResourceType):
             rest_base_path="v1/metrics",
             webpage_base_path="metric/summary?metric=",
             max_concurrency=max_concurrency,
-            pagination_strategy=NoPagination,
+            pagination_strategy=NoPagination(),
         )
         self.rest_base_path = "v1/metrics"
         self.concurrency_semaphore = asyncio.BoundedSemaphore(max_concurrency)

--- a/src/dogcrud/core/metric_resource_type.py
+++ b/src/dogcrud/core/metric_resource_type.py
@@ -90,7 +90,7 @@ class MetricResourceType(ResourceType):
     def transform_get_to_put(self, data: bytes) -> bytes:
         metric_tag_data = MetricTagDataModel.model_validate_json(data)
         metric_tag = MetricTagModel(data=metric_tag_data)
-        return metric_tag.model_dump_json(exclude_none=True)
+        return metric_tag.model_dump_json(exclude_none=True).encode()
 
     @override
     async def list_ids(self) -> AsyncGenerator[IDType]:


### PR DESCRIPTION
- Add `py.typed` to indicate inline types are present per [PEP 561 – Distributing and Packaging Type Information](https://peps.python.org/pep-0561/).
- Fix type hints
- Run mypy in pull requests