### PR TITLE
Add support for workflow automations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dogcrud"
 dynamic = ["version"]
 description = "Datadog CRUD resources from the command line."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
 	"aiofiles~=24.1.0",
 	"aiohttp[speedups]~=3.11.11",
@@ -40,6 +40,9 @@ dogcrud = "dogcrud.cli.main:cli"
 
 [tool.hatch.version]
 path = "src/dogcrud/__about__.py"
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.12", "3.13"]
 
 [tool.hatch.envs.types]
 extra-dependencies = [

--- a/src/dogcrud/cli/main.py
+++ b/src/dogcrud/cli/main.py
@@ -54,6 +54,14 @@ from dogcrud.core.logging import setup_logger
     default=4096,
     help="Try to raise the ulimit if it's below this number. This tool opens lots of concurrent file handles.",
 )
+@click.option(
+    "--skip-unsupported-workflows/--no-skip-unsupported-workflows",
+    default=False,
+    help="Skip workflows that cannot be retrieved due to Datadog API limitations. "
+    "Some workflow features (Handle triggers, iterators, etc.) are not supported "
+    "by Datadog's public API. When enabled, these workflows are skipped with a "
+    "warning showing the specific API error.",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -63,6 +71,7 @@ def cli(
     max_concurrent_requests: int,
     data_dir: pathlib.Path,
     min_open_files_limit: int,
+    skip_unsupported_workflows: bool,
 ):
     """
     Utility for working with Datadog CRUD resources.
@@ -88,6 +97,7 @@ def cli(
                 dd_app_key=dd_app_key,
                 max_concurrent_requests=max_concurrent_requests,
                 data_dir=data_dir,
+                skip_unsupported_workflows=skip_unsupported_workflows,
             )
         )
     )

--- a/src/dogcrud/cli/main.py
+++ b/src/dogcrud/cli/main.py
@@ -71,7 +71,7 @@ def cli(
     max_concurrent_requests: int,
     data_dir: pathlib.Path,
     min_open_files_limit: int,
-    skip_unsupported_workflows: bool,
+    skip_unsupported_workflows: bool,  # noqa: FBT001
 ):
     """
     Utility for working with Datadog CRUD resources.

--- a/src/dogcrud/cli/save.py
+++ b/src/dogcrud/cli/save.py
@@ -103,6 +103,6 @@ async def save_resource(resource_type: ResourceType, resource_id: str) -> None:
             logger.warning(f"Skipping {resource_type.rest_path()}/{resource_id}: {error_detail}")
         else:
             raise
-    except aiohttp.client_exceptions.ClientResponseError as e:
+    except aiohttp.client_exceptions.ClientResponseError:
         # Re-raise other HTTP errors
         raise

--- a/src/dogcrud/cli/save.py
+++ b/src/dogcrud/cli/save.py
@@ -93,7 +93,7 @@ async def save_resource(resource_type: ResourceType, resource_id: str) -> None:
     except DatadogAPIBadRequestError as e:
         # Some workflow features aren't supported by Datadog's public API
         skip_unsupported = config_context().skip_unsupported_workflows
-        if skip_unsupported and "workflows" in resource_type.rest_path():
+        if skip_unsupported and resource_type.rest_path() == "v2/workflows":
             try:
                 error_data = orjson.loads(e.error_body)
                 error_detail = error_data.get("errors", [{}])[0].get("detail", "Unknown error")

--- a/src/dogcrud/cli/save.py
+++ b/src/dogcrud/cli/save.py
@@ -4,12 +4,15 @@
 import asyncio
 import logging
 
+import aiohttp.client_exceptions
 import click
+import orjson
 
 from dogcrud.core import data
 from dogcrud.core.context import config_context
 from dogcrud.core.resource_type import ResourceType
 from dogcrud.core.resource_type_registry import resource_types
+from dogcrud.core.rest import DatadogAPIBadRequestError
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +36,12 @@ def create_save_command(rt: ResourceType):
     )
     @click.argument("resource_id", type=str)
     def save_resource_command(resource_id: str):
+        skip_unsupported_workflows = config_context().skip_unsupported_workflows
         match resource_id:
             case _ if resource_id.lower() == "all":
-                coro = save_all_resources_of_type(rt)
+                coro = save_all_resources_of_type(rt, skip_unsupported_workflows)
             case _:
-                coro = save_resource(rt, resource_id)
+                coro = save_resource(rt, resource_id, skip_unsupported_workflows)
         config_context().run_in_context(coro)
 
 
@@ -57,16 +61,17 @@ def save_all() -> None:
     """
     Save all datadog resources.
     """
-    config_context().run_in_context(save_all_resources())
+    skip_unsupported_workflows = config_context().skip_unsupported_workflows
+    config_context().run_in_context(save_all_resources(skip_unsupported_workflows))
 
 
-async def save_all_resources():
+async def save_all_resources(skip_unsupported_workflows: bool = False):
     async with asyncio.TaskGroup() as tg:
         for resource_type in resource_types():
-            tg.create_task(save_all_resources_of_type(resource_type))
+            tg.create_task(save_all_resources_of_type(resource_type, skip_unsupported_workflows))
 
 
-async def save_all_resources_of_type(resource_type: ResourceType) -> None:
+async def save_all_resources_of_type(resource_type: ResourceType, skip_unsupported: bool = False) -> None:
     prefix = f"save all {resource_type.rest_path()}"
     logger.info(f"{prefix}: Starting")
 
@@ -74,15 +79,31 @@ async def save_all_resources_of_type(resource_type: ResourceType) -> None:
 
     async with asyncio.TaskGroup() as tg:
         async for resource_id in resource_type.list_ids():
-            tg.create_task(save_resource(resource_type, str(resource_id)))
+            tg.create_task(save_resource(resource_type, str(resource_id), skip_unsupported))
             num_saved += 1
 
     logger.info(f"{prefix} Saved {num_saved} items.")
 
 
-async def save_resource(resource_type: ResourceType, resource_id: str) -> None:
-    json = await resource_type.get(resource_id)
-    resource_type.local_path().mkdir(exist_ok=True, parents=True)
-    filename = resource_type.local_path(resource_id)
-    await data.write_formatted_json(json, str(filename))
-    logger.info(f"Saved {filename}")
+async def save_resource(resource_type: ResourceType, resource_id: str, skip_unsupported: bool = False) -> None:
+    try:
+        json = await resource_type.get(resource_id)
+        resource_type.local_path().mkdir(exist_ok=True, parents=True)
+        filename = resource_type.local_path(resource_id)
+        await data.write_formatted_json(json, str(filename))
+        logger.info(f"Saved {filename}")
+    except DatadogAPIBadRequestError as e:
+        # Some workflow features aren't supported by Datadog's public API
+        if skip_unsupported and "workflows" in resource_type.rest_path():
+            try:
+                error_data = orjson.loads(e.error_body)
+                error_detail = error_data.get("errors", [{}])[0].get("detail", "Unknown error")
+            except Exception:
+                error_detail = e.error_body
+
+            logger.warning(f"Skipping {resource_type.rest_path()}/{resource_id}: {error_detail}")
+        else:
+            raise
+    except aiohttp.client_exceptions.ClientResponseError as e:
+        # Re-raise other HTTP errors
+        raise

--- a/src/dogcrud/cli/save.py
+++ b/src/dogcrud/cli/save.py
@@ -94,12 +94,8 @@ async def save_resource(resource_type: ResourceType, resource_id: str) -> None:
         # Some workflow features aren't supported by Datadog's public API
         skip_unsupported = config_context().skip_unsupported_workflows
         if skip_unsupported and resource_type.rest_path() == "v2/workflows":
-            try:
-                error_data = orjson.loads(e.error_body)
-                error_detail = error_data.get("errors", [{}])[0].get("detail", "Unknown error")
-            except Exception:
-                error_detail = e.error_body
-
+            error_data = orjson.loads(e.error_body)
+            error_detail = error_data.get("errors", [{}])[0].get("detail", "Unknown error")
             logger.warning(f"Skipping {resource_type.rest_path()}/{resource_id}: {error_detail}")
         else:
             raise

--- a/src/dogcrud/core/context.py
+++ b/src/dogcrud/core/context.py
@@ -32,6 +32,7 @@ class ConfigContext:
     dd_app_key: str
     max_concurrent_requests: int
     data_dir: pathlib.Path
+    skip_unsupported_workflows: bool = False
 
     def run_in_context(self, main: Coroutine) -> None:
         asyncio.run(self.in_context(main))

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -7,7 +7,6 @@ from functools import partial
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
 from dogcrud.core.pagination import (
-    CursorPagination,
     IDOffsetPagination,
     ItemOffsetPagination,
     NoPagination,

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -7,6 +7,7 @@ from functools import partial
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
 from dogcrud.core.pagination import (
+    CursorPagination,
     IDOffsetPagination,
     ItemOffsetPagination,
     NoPagination,
@@ -55,6 +56,12 @@ def resource_types() -> Sequence[ResourceType]:
             webpage_base_path="logs/pipelines/generate-metrics",
             max_concurrency=100,
             pagination_strategy=NoPagination(items_key="data"),
+        ),
+        StandardResourceType(
+            rest_base_path="v2/workflows",
+            webpage_base_path="workflow",
+            max_concurrency=100,
+            pagination_strategy=CursorPagination(),
         ),
         MetricMetadataResourceType(
             max_concurrency=100,

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -61,7 +61,7 @@ def resource_types() -> Sequence[ResourceType]:
             rest_base_path="v2/workflows",
             webpage_base_path="workflow",
             max_concurrency=100,
-            pagination_strategy=CursorPagination(),
+            pagination_strategy=NoPagination(items_key="data"),
         ),
         MetricMetadataResourceType(
             max_concurrency=100,


### PR DESCRIPTION
Not all workflow automations can be saved using the public API, therefore I also added a flag that allows you to treat these failures as a warning and not an error that would return a non-zero exit code.