### PR TITLE
Add Slack channel resource type

### DIFF
--- a/src/dogcrud/cli/save.py
+++ b/src/dogcrud/cli/save.py
@@ -91,8 +91,8 @@ async def save_all_resources_of_type(resource_type: ResourceType) -> None:
 async def save_resource(resource_type: ResourceType, resource_id: str) -> None:
     try:
         json = await resource_type.get(resource_id)
-        resource_type.local_path().mkdir(exist_ok=True, parents=True)
         filename = resource_type.local_path(resource_id)
+        filename.parent.mkdir(exist_ok=True, parents=True)
         await data.write_formatted_json(json, str(filename))
         logger.info(f"Saved {filename}")
     except DatadogAPIBadRequestError as e:

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -13,6 +13,7 @@ from dogcrud.core.pagination import (
 )
 from dogcrud.core.reference_table_resource_type import ReferenceTableResourceType
 from dogcrud.core.resource_type import ResourceType
+from dogcrud.core.slack_channel_resource_type import SlackChannelResourceType
 from dogcrud.core.standard_resource_type import StandardResourceType
 from dogcrud.core.transformers import data_at_key
 
@@ -71,6 +72,9 @@ def resource_types() -> Sequence[ResourceType]:
             max_concurrency=100,
         ),
         MetricResourceType(
+            max_concurrency=100,
+        ),
+        SlackChannelResourceType(
             max_concurrency=100,
         ),
     )

--- a/src/dogcrud/core/slack_channel_resource_type.py
+++ b/src/dogcrud/core/slack_channel_resource_type.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
+# SPDX-License-Identifier: MIT
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import override
+from urllib.parse import quote
+
+import aiofiles
+import orjson
+
+from dogcrud.core import context, rest
+from dogcrud.core.resource_type import IDType, ResourceType
+
+logger = logging.getLogger(__name__)
+
+_REST_BASE = "v1/integration/slack/configuration/accounts"
+
+
+class SlackChannelResourceType(ResourceType):
+    """
+    Datadog Slack integration channels.
+
+    Channels are nested under Slack account (workspace) names, so the resource
+    ID is "{account_name}/{channel_name}" (e.g. "my-workspace/#alerts").
+
+    https://docs.datadoghq.com/api/latest/slack-integration/
+    """
+
+    def __init__(self, max_concurrency: int, *, disabled: bool = False) -> None:
+        self.concurrency_semaphore = asyncio.BoundedSemaphore(max_concurrency)
+        self.disabled = disabled
+
+    @override
+    def rest_path(self, resource_id: IDType | None = None) -> str:
+        match resource_id:
+            case None:
+                return _REST_BASE
+            case _:
+                account, _, channel = str(resource_id).partition("/")
+                return f"{_REST_BASE}/{account}/channels/{quote(channel, safe='')}"
+
+    @override
+    def local_path(self, resource_id: IDType | None = None) -> Path:
+        data_dir = context.config_context().data_dir
+        match resource_id:
+            case None:
+                return data_dir / _REST_BASE
+            case _:
+                account, _, channel = str(resource_id).partition("/")
+                return data_dir / _REST_BASE / account / f"{channel}.json"
+
+    @override
+    async def get(self, resource_id: IDType) -> bytes:
+        async with self.concurrency_semaphore:
+            return await rest.get_json(f"api/{self.rest_path(resource_id)}")
+
+    @override
+    async def put(self, resource_id: IDType, data: bytes) -> None:
+        async with self.concurrency_semaphore:
+            await rest.patch_json(f"api/{self.rest_path(resource_id)}", data)
+
+    @override
+    def transform_get_to_put(self, data: bytes) -> bytes:
+        return data
+
+    @override
+    async def list_ids(self) -> AsyncGenerator[IDType]:
+        # GET /api/v1/integration/slack returns the full config with all accounts
+        # and channels: {"channels": [{"account": "...", "channel_name": "..."}, ...]}
+        async with self.concurrency_semaphore:
+            integration_json = await rest.get_json("api/v1/integration/slack")
+        integration: dict = orjson.loads(integration_json)
+        for channel in integration.get("channels", []):
+            yield f"{channel['account']}/{channel['channel_name']}"
+
+    @override
+    async def read_local_json(self, resource_id: IDType) -> bytes:
+        async with aiofiles.open(str(self.local_path(resource_id)), "rb") as file:
+            return await file.read()
+
+    @override
+    def webpage_url(self, resource_id: IDType) -> str:
+        return "https://app.datadoghq.com/account/settings#integrations/slack"
+
+    @override
+    def resource_id(self, filename: str) -> IDType:
+        path = Path(filename)
+        # path: .../v1/integration/slack/configuration/accounts/{account}/{channel}.json
+        channel_name = path.stem
+        account_name = path.parent.name
+        return f"{account_name}/{channel_name}"


### PR DESCRIPTION
## Summary

- Adds `SlackChannelResourceType` for saving/restoring Datadog Slack integration channels
- Resource ID is `{account_name}/{channel_name}` (e.g. `my-workspace/#alerts`); files saved under `v1/integration/slack/configuration/accounts/{account}/{channel}.json`
- Uses `GET /api/v1/integration/slack` to enumerate all channels across all workspaces, then `GET/PATCH` per-channel endpoints for save/restore
- Fixes `save.py` to use `filename.parent.mkdir()` instead of `rt.local_path().mkdir()` so nested local paths work correctly (backward-compatible with all existing resource types)

## Test plan

- [x] `dogcrud save v1/integration/slack/configuration/accounts all` — saved all channels successfully
- [x] `dogcrud restore` on a test channel — flipped a display toggle, verified via API, reverted back

🤖 Assisted by [Claude Code](https://claude.com/claude-code)