### PR TITLE
Switch publish workflow to PyPI trusted publishers (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: production
+    environment: publishing
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,8 @@ on:
   release:
     types: [published]
 
+# id-token: write is required for PyPI trusted publishing (OIDC).
+# See https://docs.pypi.org/trusted-publishers/ for details.
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -24,5 +25,3 @@ jobs:
 
     - name: Upload distributions.
       run: uv publish
-      env:
-        UV_PUBLISH_TOKEN: ${{ secrets.HATCH_INDEX_AUTH }}


### PR DESCRIPTION
## Summary

Switched from API token authentication to PyPI trusted publishing (OIDC). See https://docs.pypi.org/trusted-publishers/ for details.

- Added `id-token: write` permission so GitHub Actions can request an OIDC token
- Removed `UV_PUBLISH_TOKEN` env var — no stored secret needed
- `uv publish` will automatically use the OIDC token to get a short-lived PyPI token

## Status

Publishing is currently broken because the `HATCH_INDEX_AUTH` secret was removed in anticipation of this PR. Still need to:
- Configure a trusted publisher on PyPI (project → **Publishing** tab: GitHub, repo `drichardson/dogcrud`, workflow `publish.yaml`, environment `publishing`). This has been done at https://pypi.org/manage/project/dogcrud/settings/publishing/
- Test publishing from a branch before merging. Confirmed in https://github.com/drichardson/dogcrud/actions/runs/23116339161/job/67142427507

## GitHub Environment

The workflow uses the `publishing` GitHub Actions environment. Configuring this environment is optional but strongly recommended — it allows applying additional restrictions such as requiring manual approval from trusted maintainers before each publish run. See [Adding a Trusted Publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) for more details.