### PR TITLE
Add incident resource type (v1.9.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "dogcrud"
-version = "1.8.1"
+version = "1.9.0"
 description = "Datadog CRUD resources from the command line."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dogcrud/core/incident_resource_type.py
+++ b/src/dogcrud/core/incident_resource_type.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
+# SPDX-License-Identifier: MIT
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import override
+
+import aiofiles
+import orjson
+
+from dogcrud.core import context, rest
+from dogcrud.core.pagination import LimitOffsetPagination
+from dogcrud.core.resource_type import IDType, ResourceType
+
+logger = logging.getLogger(__name__)
+
+_REST_BASE = "v2/incidents"
+
+_PAGINATION = LimitOffsetPagination(
+    limit=100,
+    limit_query_param="page[size]",
+    offset_query_param="page[offset]",
+    items_key="data",
+)
+
+
+class IncidentResourceType(ResourceType):
+    """
+    Datadog Incident resource.
+
+    List:   GET /api/v2/incidents            (page[size] / page[offset] pagination)
+    Get:    GET /api/v2/incidents/{id}       (response wrapped in "data" key)
+    Update: PATCH /api/v2/incidents/{id}    (PATCH, not PUT)
+
+    https://docs.datadoghq.com/api/latest/incidents/
+    """
+
+    def __init__(self, max_concurrency: int, *, disabled: bool = False) -> None:
+        self.concurrency_semaphore = asyncio.BoundedSemaphore(max_concurrency)
+        self.disabled = disabled
+
+    @override
+    def rest_path(self, resource_id: IDType | None = None) -> str:
+        match resource_id:
+            case None:
+                return _REST_BASE
+            case _:
+                return f"{_REST_BASE}/{resource_id}"
+
+    @override
+    def local_path(self, resource_id: IDType | None = None) -> Path:
+        data_dir = context.config_context().data_dir
+        match resource_id:
+            case None:
+                return data_dir / _REST_BASE
+            case _:
+                return data_dir / f"{_REST_BASE}/{resource_id}.json"
+
+    @override
+    async def get(self, resource_id: IDType) -> bytes:
+        async with self.concurrency_semaphore:
+            return await rest.get_json(f"api/{self.rest_path(resource_id)}")
+
+    @override
+    async def put(self, resource_id: IDType, data: bytes) -> None:
+        async with self.concurrency_semaphore:
+            await rest.patch_json(f"api/{self.rest_path(resource_id)}", data)
+
+    @override
+    def transform_get_to_put(self, data: bytes) -> bytes:
+        """
+        The GET response has shape {"data": {...}, "included": [...], ...}.
+        The PATCH payload expects {"data": {...}}.
+        Extract just the "data" key and re-wrap it.
+        """
+        parsed = orjson.loads(data)
+        return orjson.dumps({"data": parsed["data"]})
+
+    @override
+    async def list_ids(self) -> AsyncGenerator[IDType]:
+        async for page in _PAGINATION.pages(
+            f"api/{self.rest_path()}", self.concurrency_semaphore
+        ):
+            for id_ in page.ids:
+                yield id_
+
+    @override
+    async def read_local_json(self, resource_id: IDType) -> bytes:
+        async with aiofiles.open(str(self.local_path(resource_id)), "rb") as file:
+            return await file.read()
+
+    @override
+    def webpage_url(self, resource_id: IDType) -> str:
+        return f"https://app.datadoghq.com/incidents/{resource_id}"
+
+    @override
+    def resource_id(self, filename: str) -> IDType:
+        return Path(filename).stem

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -4,6 +4,7 @@
 from collections.abc import Sequence
 from functools import partial
 
+from dogcrud.core.incident_resource_type import IncidentResourceType
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
 from dogcrud.core.pagination import (
@@ -79,6 +80,9 @@ def resource_types() -> Sequence[ResourceType]:
             max_concurrency=100,
         ),
         SlackChannelResourceType(
+            max_concurrency=100,
+        ),
+        IncidentResourceType(
             max_concurrency=100,
         ),
     )


### PR DESCRIPTION
## Background

Datadog's [Incidents API](https://docs.datadoghq.com/api/latest/incidents/) provides access to incident management data. This adds `v2/incidents` as a supported resource type so incidents can be saved and restored like other Datadog resources.

## Changes

- **New**: `src/dogcrud/core/incident_resource_type.py` — custom `ResourceType` implementation for incidents
  - List: `GET /api/v2/incidents` with `page[size]`/`page[offset]` pagination
  - Fetch: `GET /api/v2/incidents/{id}`
  - Restore: `PATCH /api/v2/incidents/{id}` (incidents use PATCH, not PUT)
  - `transform_get_to_put` strips top-level read-only fields (e.g. `included`), keeping just `{"data": {...}}` as the PATCH payload
- **Modified**: `src/dogcrud/core/resource_type_registry.py` — registers `IncidentResourceType(max_concurrency=100)`
- **Version bump**: `1.8.1` → `1.9.0`

## Testing

- `uv run ruff format && uv run ruff check` — passes
- `uv run mypy src` — passes
- `uv run pytest` — passes
- `doppler run -- uv run dogcrud save v2/incidents all` — successfully saved 1200+ incidents (rate limited as expected since the API is in beta)

## Other Considerations

- The Incidents API is currently in beta and is heavily rate limited. The existing exponential backoff and rate limit handling in `rest.py` handles this gracefully.
- Incident JSON contains user references (commander, responders, etc.) as opaque UUIDs — these are org-specific and won't be portable if restoring to a different org.
- The app key requires the `INCIDENT_READ` Datadog permission scope.