### PR TITLE
Add incident attachments resource type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents Guide
 
-Read `DESIGN.md` first for an understanding of the codebase structure, concurrency model, and how to add new Datadog REST resources.
+Read `DESIGN.md` first for an understanding of the codebase structure, concurrency model, and how to add new Datadog REST resources. See `MAINTAINERS.md` for version bumps and other recurring tasks.
 
 ## Development Commands
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -149,3 +149,52 @@ dogcrud list v2/my-resource
 dogcrud save v2/my-resource all
 dogcrud restore saved/v2/my-resource/<id>.json
 ```
+
+---
+
+## Child Resources (1:Many Relationships)
+
+Some Datadog resources are children of another resource — for example, incident attachments belong to incidents. These are accessed via endpoints like `GET /api/v2/incidents/{incident_id}/attachments` and have no standalone list endpoint.
+
+### Directory Convention
+
+Child resources use a **separate top-level directory** rather than nesting inside the parent's directory. The directory is named `{parent}-{child}` with the parent resource's ID as the filename:
+
+```
+saved/v2/incident-attachments/{incident_id}.json
+```
+
+**Not** nested under the parent:
+
+```
+# DON'T — mixes files and directories, causes path-prefix collisions
+saved/v2/incidents/{incident_id}/attachments.json
+```
+
+This convention exists for two reasons:
+
+1. **Path-prefix isolation** — `resource_type_for_filename()` in `data.py` matches files to resource types by substring-matching `local_path()`. If child resources lived under the parent's directory (e.g. `v2/incidents/attachments/`), files would match both the parent and child resource types.
+
+2. **Homogeneous directories** — each directory under `saved/` contains only `.json` files (no subdirectories mixed with files), keeping the structure predictable and consistent.
+
+### Implementation Pattern
+
+Child resource types implement `ResourceType` directly. The key difference from standard resources is that `list_ids()` enumerates the **parent** resource's IDs (since there is no standalone child list endpoint), and `get()` fetches the child collection for a given parent ID:
+
+- `list_ids()` — pages through the parent resource's list endpoint to yield parent IDs
+- `get(parent_id)` — `GET /api/{parent_path}/{parent_id}/{child_path}`
+- `local_path(parent_id)` — `data_dir / "{parent}-{child}/{parent_id}.json"`
+- `rest_path()` (no arg) — `"{parent}-{child}"` (used as the CLI command name)
+
+Each saved file contains the **full API response** for that parent's children (the entire list, not individual items), since the API returns all children in a single request with no per-item GET endpoint.
+
+The save flow for `dogcrud save v2/incident-attachments all`:
+
+1. `list_ids()` pages through `GET /api/v2/incidents` to collect all incident IDs
+2. `TaskGroup` fans out one task per incident ID
+3. Each task calls `get(incident_id)` → `GET /api/v2/incidents/{incident_id}/attachments`
+4. Response written to `saved/v2/incident-attachments/{incident_id}.json`
+
+### Read-Only Child Resources
+
+Some child resource endpoints only support GET (e.g., incident attachments is a Preview API with no write support). These resource types raise `NotImplementedError` from `put()` and `transform_get_to_put()`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,11 +19,23 @@ $ uv run dogcrud
 Usage: dogcrud [OPTIONS] COMMAND [ARGS]...
 ```
 
+## Updating `pyproject.toml`
+
+When updating `pyproject.toml` — whether bumping the version of dogcrud itself
+or changing any dependencies — run `uv lock` afterward to keep `uv.lock` in
+sync. Commit both files together.
+
+```sh
+uv lock
+git add pyproject.toml uv.lock
+```
+
 ## Publishing
 
 To publish a release to [PyPI](https://pypi.org/project/dogcrud/):
 
-1. Create a PR to bump the version. Edit `version` in `pyproject.toml`.
+1. Create a PR to bump the version. Edit `version` in `pyproject.toml`, then run
+   `uv lock` to sync `uv.lock`. Commit both files together.
 2. Merge the PR to main
 3. Go to [releases](https://github.com/drichardson/dogcrud/releases).
 4. Draft a new release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "dogcrud"
-version = "1.9.0"
+version = "1.10.0"
 description = "Datadog CRUD resources from the command line."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dogcrud/core/incident_attachment_resource_type.py
+++ b/src/dogcrud/core/incident_attachment_resource_type.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
+# SPDX-License-Identifier: MIT
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import override
+
+import aiofiles
+
+from dogcrud.core import context, rest
+from dogcrud.core.pagination import LimitOffsetPagination
+from dogcrud.core.resource_type import IDType, ResourceType
+
+logger = logging.getLogger(__name__)
+
+_REST_BASE = "v2/incident-attachments"
+_INCIDENTS_REST_BASE = "v2/incidents"
+
+_INCIDENT_PAGINATION = LimitOffsetPagination(
+    limit=100,
+    limit_query_param="page[size]",
+    offset_query_param="page[offset]",
+    items_key="data",
+)
+
+
+class IncidentAttachmentResourceType(ResourceType):
+    """
+    Datadog Incident Attachments child resource.
+
+    Attachments are 1:many with incidents. There is no standalone list endpoint;
+    instead list_ids() enumerates all incident IDs and get() fetches the
+    attachment list for each incident.
+
+    List incidents: GET /api/v2/incidents              (page[size] / page[offset])
+    Get:            GET /api/v2/incidents/{id}/attachments  (all attachments, one call)
+
+    Files are saved at:
+        saved/v2/incident-attachments/{incident_id}.json
+
+    See "Child Resources (1:Many Relationships)" in DESIGN.md for the convention.
+
+    https://docs.datadoghq.com/api/latest/incidents/#list-incident-attachments
+    """
+
+    def __init__(self, max_concurrency: int, *, disabled: bool = False) -> None:
+        self.concurrency_semaphore = asyncio.BoundedSemaphore(max_concurrency)
+        self.disabled = disabled
+
+    @override
+    def rest_path(self, resource_id: IDType | None = None) -> str:
+        # rest_path() with no arg is used as the CLI command name and local
+        # directory prefix. With an arg it becomes the actual API endpoint.
+        match resource_id:
+            case None:
+                return _REST_BASE
+            case _:
+                return f"{_INCIDENTS_REST_BASE}/{resource_id}/attachments"
+
+    @override
+    def local_path(self, resource_id: IDType | None = None) -> Path:
+        data_dir = context.config_context().data_dir
+        match resource_id:
+            case None:
+                return data_dir / _REST_BASE
+            case _:
+                return data_dir / _REST_BASE / f"{resource_id}.json"
+
+    @override
+    async def get(self, resource_id: IDType) -> bytes:
+        async with self.concurrency_semaphore:
+            return await rest.get_json(f"api/{self.rest_path(resource_id)}")
+
+    @override
+    async def put(self, resource_id: IDType, data: bytes) -> None:
+        raise NotImplementedError(
+            "Incident attachments are read-only; restore is not supported."
+        )
+
+    @override
+    def transform_get_to_put(self, data: bytes) -> bytes:
+        raise NotImplementedError(
+            "Incident attachments are read-only; restore is not supported."
+        )
+
+    @override
+    async def list_ids(self) -> AsyncGenerator[IDType]:
+        async for page in _INCIDENT_PAGINATION.pages(
+            f"api/{_INCIDENTS_REST_BASE}", self.concurrency_semaphore
+        ):
+            for id_ in page.ids:
+                yield id_
+
+    @override
+    async def read_local_json(self, resource_id: IDType) -> bytes:
+        async with aiofiles.open(str(self.local_path(resource_id)), "rb") as file:
+            return await file.read()
+
+    @override
+    def webpage_url(self, resource_id: IDType) -> str:
+        return f"https://app.datadoghq.com/incidents/{resource_id}"
+
+    @override
+    def resource_id(self, filename: str) -> IDType:
+        return Path(filename).stem

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -4,6 +4,9 @@
 from collections.abc import Sequence
 from functools import partial
 
+from dogcrud.core.incident_attachment_resource_type import (
+    IncidentAttachmentResourceType,
+)
 from dogcrud.core.incident_resource_type import IncidentResourceType
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
@@ -83,6 +86,9 @@ def resource_types() -> Sequence[ResourceType]:
             max_concurrency=100,
         ),
         IncidentResourceType(
+            max_concurrency=100,
+        ),
+        IncidentAttachmentResourceType(
             max_concurrency=100,
         ),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "dogcrud"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "dogcrud"
-version = "1.8.1"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Background

Incident attachments are a 1:many child resource of incidents, accessed via `GET /api/v2/incidents/{incident_id}/attachments`. This pattern doesn't fit the existing flat `StandardResourceType` model, so we needed to establish a convention before implementing.

## Changes

- **`DESIGN.md`** — Documents the new child resource convention: child resources use a separate top-level directory named `{parent}-{child}` (e.g. `v2/incident-attachments/`) with the parent ID as the filename. Explains the two motivations: path-prefix isolation (avoids collisions in `resource_type_for_filename()`) and homogeneous directories (no mixing of files and subdirectories).

- **`incident_attachment_resource_type.py`** — New `IncidentAttachmentResourceType` implementing `ResourceType` directly. `list_ids()` paginates through `GET /api/v2/incidents` to enumerate parent IDs; `get(incident_id)` fetches `GET /api/v2/incidents/{incident_id}/attachments`. Files saved at `saved/v2/incident-attachments/{incident_id}.json`. `put()` and `transform_get_to_put()` raise `NotImplementedError` since this is a read-only Preview API.

- **`resource_type_registry.py`** — Registers `IncidentAttachmentResourceType`, making `dogcrud save v2/incident-attachments all` and `dogcrud list v2/incident-attachments` available automatically.

- **`MAINTAINERS.md`** — Added a `## Updating pyproject.toml` section documenting that `uv lock` must be run (and `uv.lock` committed) whenever `pyproject.toml` is changed. Also updated the Publishing section to mention this inline at the version bump step.

- **`AGENTS.md`** — Added a reference to `MAINTAINERS.md` in the opening line.

- **`uv.lock`** — Synced from `1.9.0` (which was missing from the prior version bump commit) and bumped to `1.10.0`.

- **`pyproject.toml`** — Bumped version to `1.10.0`.

## Testing

- `uv run pytest` — passes
- `uv run mypy src` — no issues
- `uv run ruff format && uv run ruff check` — clean

## Other Considerations

The `list_ids()` implementation re-fetches incident IDs from the API independently of `IncidentResourceType`. When `dogcrud save all` runs, both resource types will page through `GET /api/v2/incidents` separately — redundant but correct. A shared DAG-based dependency optimization is possible in the future but not necessary for correctness.