### PR TITLE
Add Taskfile.dist.yaml and adopt task in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install Task
+      uses: go-task/setup-task@v1
+
     - name: Run Tests
-      run: uv run ${{ matrix.resolution == 'lowest-direct' && '--resolution lowest-direct' || '' }} pytest
+      run: task test
+      env:
+        UV_RESOLUTION: ${{ matrix.resolution == 'lowest-direct' && 'lowest-direct' || '' }}
 
   lint:
     runs-on: ubuntu-latest
@@ -38,16 +43,17 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 
-    - name: Formatting and checks
-      run: |
-        uv run ruff format --check
-        uv run ruff check
+    - name: Install Task
+      uses: go-task/setup-task@v1
+
+    - name: Lint
+      run: task lint
 
     - name: Check Python classifiers match CI matrix
-      run: scripts/check_python_classifiers.py
+      run: task check-classifiers
 
-    - name: Check Types
-      run: uv run mypy src/dogcrud tests
+    - name: Typecheck
+      run: task typecheck
 
   check:
     if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,15 @@ jobs:
     - name: Install Task
       uses: go-task/setup-task@v1
 
-    - name: Run Tests
+    - name: Run Tests (locked)
+      if: matrix.resolution == 'locked'
+      run: task test
+
+    - name: Run Tests (lowest-direct)
+      if: matrix.resolution == 'lowest-direct'
       run: task test
       env:
-        UV_RESOLUTION: ${{ matrix.resolution == 'lowest-direct' && 'lowest-direct' || '' }}
+        UV_RESOLUTION: lowest-direct
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 dist/
 saved/
 .venv/
+Taskfile.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,21 @@ Read `DESIGN.md` first for an understanding of the codebase structure, concurren
 
 ## Development Commands
 
+Preferred: use [Task](https://taskfile.dev) (`brew install go-task` on macOS):
+
+```sh
+task test            # run tests
+task typecheck       # type checking
+task lint            # check formatting and lint
+task format          # auto-format (local dev)
+task check           # run all checks (lint + typecheck + test)
+```
+
+Equivalent raw commands:
+
 ```sh
 uv run pytest                          # run tests
-uv run mypy src                        # type checking
+uv run mypy src/dogcrud tests          # type checking
 uv run ruff format && uv run ruff check  # format and lint
 ```
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,26 @@
 # Maintainers Guide
 
-This package is developed using [uv](https://docs.astral.sh/uv/). You'll
-need to install uv (e.g. `brew install uv` on macos).
+This package is developed using [uv](https://docs.astral.sh/uv/) and
+[Task](https://taskfile.dev). Install both:
+
+```sh
+brew install uv go-task  # macOS
+```
+
+## Common tasks
+
+Use `task` for day-to-day development (defined in `Taskfile.dist.yaml`):
+
+```sh
+task test            # run tests
+task typecheck       # type checking
+task lint            # check formatting and lint
+task format          # auto-format code
+task check           # run all checks (lint + typecheck + test)
+```
+
+You can create a local `Taskfile.yaml` to override or extend tasks for your
+own environment — it is gitignored.
 
 ## Some `uv` commands you will use
 

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+tasks:
+  format:
+    desc: Auto-format code with ruff
+    cmd: uv run ruff format
+
+  lint:
+    desc: Check formatting and run linter
+    cmds:
+      - uv run ruff format --check
+      - uv run ruff check
+
+  typecheck:
+    desc: Run mypy type checker
+    cmd: uv run mypy src/dogcrud tests
+
+  test:
+    desc: Run tests
+    cmd: uv run pytest
+
+  check-classifiers:
+    desc: Verify pyproject.toml classifiers match CI matrix
+    cmd: scripts/check_python_classifiers.py
+
+  check:
+    desc: Run all checks (lint, typecheck, test)
+    cmds:
+      - task: lint
+      - task: typecheck
+      - task: test


### PR DESCRIPTION
## Background

Introduces [Task](https://taskfile.dev) as the standard way to run development commands in this repo.

## Changes

- Add `Taskfile.dist.yaml` with tasks: `format`, `lint`, `typecheck`, `test`, `check`, `check-classifiers`
- Update `.github/workflows/ci.yaml` to install Task via `go-task/setup-task@v1` and invoke tasks instead of raw `uv run` commands; the `lowest-direct` resolution matrix entries set `UV_RESOLUTION=lowest-direct` (a native uv env var) so `task test` just works
- Add `Taskfile.yaml` to `.gitignore` so developers can create a local override without committing it
- Update `AGENTS.md` and `MAINTAINERS.md` to document Task as the preferred dev workflow

## Testing

Tasks verified locally:

```sh
task lint       # passes
task typecheck  # passes
task test       # passes
```

## Other Considerations

`Taskfile.dist.yaml` is the committed file per Task convention — individual developers can create a local `Taskfile.yaml` (gitignored) to override or extend tasks for their own environment.

This is the first in a stack of 4 PRs:
- **PR 1 (this):** Taskfile + CI adoption
- PR 2: `git-hook` + `install-git-hooks` tasks
- PR 3: pytest-cov, `test-coverage` task, CI artifact upload
- PR 4: `version-bump` task + bump to 1.11.0