### PR TITLE
Add v1/logs/config/indexes resource type (v1.13.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-.envrc
+/.coverage
+/.envrc
+/.venv/
+/htmlcov/
+/saved/
 __pycache__/
-dist/
-saved/
-.venv/
-Taskfile.yaml
-htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "dogcrud"
-version = "1.12.0"
+version = "1.13.0"
 description = "Datadog CRUD resources from the command line."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dogcrud/cli/list.py
+++ b/src/dogcrud/cli/list.py
@@ -8,6 +8,7 @@ import click
 import orjson
 
 from dogcrud.core.context import config_context
+from dogcrud.core.logs_index_resource_type import LogsIndexResourceType
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
 from dogcrud.core.resource_type import ResourceType
@@ -94,6 +95,12 @@ async def list_all_resources_of_type(
             # Metric types override list_ids and don't support standard pagination
             items = [
                 {"id": resource_id} async for resource_id in resource_type.list_ids()
+            ]
+        case LogsIndexResourceType():
+            # Log indexes use `name` as their identifier rather than `id`
+            items = [
+                {"id": resource_id, "name": resource_id}
+                async for resource_id in resource_type.list_ids()
             ]
         case StandardResourceType():
             # StandardResourceType has pagination_strategy which provides richer item details

--- a/src/dogcrud/core/logs_index_resource_type.py
+++ b/src/dogcrud/core/logs_index_resource_type.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import override
 
+import aiohttp.client_exceptions
 import orjson
 
 from dogcrud.core import rest
@@ -53,6 +54,20 @@ class LogsIndexResourceType(StandardResourceType):
         parsed = orjson.loads(data)
         for index in parsed["indexes"]:
             yield index["name"]
+
+    @override
+    async def put(self, resource_id: IDType, data: bytes) -> None:
+        try:
+            await super().put(resource_id, data)
+        except aiohttp.client_exceptions.ClientResponseError as e:
+            if e.status == 409:  # noqa: PLR2004
+                msg = (
+                    f"Cannot restore log index '{resource_id}': Datadog does not allow "
+                    f"reusing a deleted index name. You must create a new index with a "
+                    f"different name via the Datadog UI."
+                )
+                raise RuntimeError(msg) from e
+            raise
 
     @override
     def webpage_url(self, resource_id: IDType) -> str:

--- a/src/dogcrud/core/logs_index_resource_type.py
+++ b/src/dogcrud/core/logs_index_resource_type.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025-present Doug Richardson <git@rekt.email>
+# SPDX-License-Identifier: MIT
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import override
+
+import orjson
+
+from dogcrud.core import rest
+from dogcrud.core.pagination import NoPagination
+from dogcrud.core.resource_type import IDType
+from dogcrud.core.standard_resource_type import StandardResourceType
+
+
+def _strip_read_only_fields(data: bytes) -> bytes:
+    """
+    Strip read-only fields from the GET response before sending to PUT.
+
+    The `is_rate_limited` field is returned by GET but is not accepted by PUT.
+    """
+    parsed = orjson.loads(data)
+    parsed.pop("is_rate_limited", None)
+    return orjson.dumps(parsed)
+
+
+class LogsIndexResourceType(StandardResourceType):
+    """
+    Resource type for Datadog Log Indexes.
+
+    Log indexes use `name` (a string) as their identifier rather than the
+    conventional `id` field, so list_ids() is overridden to extract `name`
+    from each item in the list response.
+
+    https://docs.datadoghq.com/api/latest/logs-indexes/
+    """
+
+    def __init__(self, max_concurrency: int) -> None:
+        super().__init__(
+            rest_base_path="v1/logs/config/indexes",
+            webpage_base_path="logs/indexes",
+            max_concurrency=max_concurrency,
+            pagination_strategy=NoPagination(items_key="indexes"),
+            get_to_put_transformer=_strip_read_only_fields,
+        )
+
+    @override
+    async def list_ids(self) -> AsyncGenerator[IDType]:
+        async with self.concurrency_semaphore:
+            data = await rest.get_json(f"api/{self.rest_path()}")
+        parsed = orjson.loads(data)
+        for index in parsed["indexes"]:
+            yield index["name"]
+
+    @override
+    def webpage_url(self, resource_id: IDType) -> str:
+        return "https://app.datadoghq.com/logs/indexes"
+
+    @override
+    def resource_id(self, filename: str) -> IDType:
+        return Path(filename).stem

--- a/src/dogcrud/core/logs_index_resource_type.py
+++ b/src/dogcrud/core/logs_index_resource_type.py
@@ -17,10 +17,12 @@ def _strip_read_only_fields(data: bytes) -> bytes:
     """
     Strip read-only fields from the GET response before sending to PUT.
 
-    The `is_rate_limited` field is returned by GET but is not accepted by PUT.
+    The `is_rate_limited` and `name` fields are returned by GET but are
+    not accepted by PUT.
     """
     parsed = orjson.loads(data)
     parsed.pop("is_rate_limited", None)
+    parsed.pop("name", None)
     return orjson.dumps(parsed)
 
 

--- a/src/dogcrud/core/resource_type_registry.py
+++ b/src/dogcrud/core/resource_type_registry.py
@@ -8,6 +8,7 @@ from dogcrud.core.incident_attachment_resource_type import (
     IncidentAttachmentResourceType,
 )
 from dogcrud.core.incident_resource_type import IncidentResourceType
+from dogcrud.core.logs_index_resource_type import LogsIndexResourceType
 from dogcrud.core.metric_metadata_resource_type import MetricMetadataResourceType
 from dogcrud.core.metric_resource_type import MetricResourceType
 from dogcrud.core.pagination import (
@@ -49,6 +50,9 @@ def resource_types() -> Sequence[ResourceType]:
             webpage_base_path="logs/pipelines/pipeline/edit",
             max_concurrency=100,
             pagination_strategy=NoPagination(),
+        ),
+        LogsIndexResourceType(
+            max_concurrency=100,
         ),
         StandardResourceType(
             rest_base_path="v1/slo",

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "dogcrud"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Background

The Datadog [Logs Indexes API](https://docs.datadoghq.com/api/latest/logs-indexes/) allows managing log index configurations — including filters, exclusion rules, daily limits, and retention settings. This PR adds support for saving and restoring log indexes via `dogcrud`.

## Changes

- **`src/dogcrud/core/logs_index_resource_type.py`** — New `LogsIndexResourceType` class, subclassing `StandardResourceType`. Key differences from a standard resource:
  - Log indexes use `name` (string) as their identifier rather than the conventional `id` field; `list_ids()` is overridden to extract `name` from each item in the list response.
  - The `is_rate_limited` and `name` read-only fields returned by GET are stripped in `transform_get_to_put` before sending to PUT (Datadog rejects both).
  - `webpage_url` points to the Logs Indexes settings page (no per-index URL exists).
  - Catches 409 Conflict on PUT (which occurs when a deleted index name is reused) and raises a clear `RuntimeError` explaining that Datadog permanently reserves deleted index names.
- **`src/dogcrud/cli/list.py`** — Adds a `LogsIndexResourceType` match case so `list` uses `list_ids()` instead of `pagination_strategy.pages()`, since the shared `_get_page` helper hardcodes `item["id"]` extraction which doesn't exist on log index objects.
- **`src/dogcrud/core/resource_type_registry.py`** — Registers `LogsIndexResourceType`, making `dogcrud list v1/logs/config/indexes` and `dogcrud save v1/logs/config/indexes all` available automatically.
- **`pyproject.toml` / `uv.lock`** — Minor version bump `1.12.0 → 1.13.0`.

## Testing

- `task check` passes (lint + mypy + pytest).
- Manually verified:
  - `dogcrud list v1/logs/config/indexes` — lists all 18 indexes.
  - `dogcrud save v1/logs/config/indexes all` — saves all indexes to disk.
  - `dogcrud restore saved/v1/logs/config/indexes/<name>.json` — successfully restores an existing index.
  - `dogcrud restore` of a deleted index — returns a clear error message explaining the Datadog limitation.

## Other Considerations

- The list endpoint (`GET /api/v1/logs/config/indexes`) returns all indexes in a single response (no pagination needed), so `NoPagination(items_key="indexes")` is used.
- Datadog permanently reserves deleted index names — they cannot be reused even via POST (Create). The restore for a deleted index will fail with a clear `RuntimeError` rather than a cryptic 409 traceback.
- Create (`POST`) is supported by the Datadog API but not wired in — `dogcrud` currently only does list/get/put (save/restore), consistent with all other resource types.