### PR TITLE
ci: restrict GITHUB_TOKEN to no permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: ci
 
 on: [push]
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Background

GitHub Actions workflows inherit broad default token permissions unless explicitly restricted. The `GITHUB_TOKEN` is available to all steps and actions in a workflow, and without explicit scoping it can be used to write to the repository, comment on issues, publish packages, etc.

## Changes

Set `permissions: {}` at the workflow level in `.github/workflows/ci.yaml`, which denies all `GITHUB_TOKEN` API scopes for every job in the workflow.

This workflow only checks out code, runs tests/lint, and uploads a coverage artifact — none of which require `GITHUB_TOKEN` API scopes. CI passes unaffected because:

- `actions/checkout` authenticates via a separate mechanism and is not blocked by `GITHUB_TOKEN` scope restrictions.
- `actions/upload-artifact` uses the Actions Artifacts runtime API, not `GITHUB_TOKEN`.

## Testing

CI passed with `permissions: {}` in place.

## Other Considerations

This is a defense-in-depth measure. If a compromised dependency or a future workflow change attempted to use `GITHUB_TOKEN` to push code, comment on PRs, or publish packages, the empty permissions block would block it.
