### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, email [dogcrud-security-reports@subs.rekt.email](mailto:dogcrud-security-reports@subs.rekt.email) with a description of the issue, steps to reproduce, and any relevant details.
+
+We will acknowledge your report within 48 hours and aim to provide a resolution timeline within 7 days.


### PR DESCRIPTION
## Background

GitHub recommends adding a `SECURITY.md` to repositories so that security researchers have clear instructions on how to responsibly disclose vulnerabilities.

## Changes

- Adds `SECURITY.md` at the repo root following GitHub's security policy convention
- Directs reporters to `dogcrud-security-reports@subs.rekt.email`
- Instructs reporters not to use public GitHub issues for security vulnerabilities

## Testing

No code changes; documentation only.

## Other Considerations

GitHub automatically surfaces `SECURITY.md` in the repository's Security tab and when users open a new issue, prompting them toward the private disclosure channel.